### PR TITLE
Fix node update

### DIFF
--- a/xmldiff/patch.py
+++ b/xmldiff/patch.py
@@ -35,8 +35,8 @@ class Patcher(object):
 
     def _handle_MoveNode(self, action, tree):
         node = tree.xpath(action.node)[0]
-        node.getparent().remove(node)
         target = tree.xpath(action.target)[0]
+        node.getparent().remove(node)
         target.insert(action.position, node)
 
     def _handle_UpdateTextIn(self, action, tree):


### PR DESCRIPTION
Fixes a bug where removing the node's parent before querying the tree for the insertion target led to failure to find an insertion target and thus an IndexError